### PR TITLE
Revert Prev type

### DIFF
--- a/src/typings/prev.ts
+++ b/src/typings/prev.ts
@@ -1,0 +1,4 @@
+/** @deprecated */
+export default interface Prev extends Partial<number[]> {
+	0: number; // FIXME: looks weird, I know, but type [ number, ...number[] ] didn't work
+}


### PR DESCRIPTION
Preserve backwards compatibility by having `Prev` type again