### PR TITLE
Build dist/ before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "errorOnDeprecated": true
   },
   "scripts": {
+    "pretest": "node --require ./dist -pe \"process.exit(0)\" || npm run build",
     "test": "jest --no-cache",
     "test:cov": "npm run test -- --coverage",
     "test:ci": "npm run test -- --no-colors",

--- a/test/build/README.md
+++ b/test/build/README.md
@@ -15,5 +15,3 @@ import entity from "../../dist/entity"; // from dist/
 
 it("should do something", () => {...
 ```
-
-The build output is created from within the test, therefore `dist/` folder might not exist before compiling the test file, since it is outside of the boundaries of project. Automatically building the source each time before each test run increases performance load, this would result in overall degraded developer experience with a little benefit. Therefore, one must ensure that the build output already exists before running tests.

--- a/test/build/browser.spec.ts
+++ b/test/build/browser.spec.ts
@@ -2,14 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { build, expectFilesInDist, expectToBeMyBoi } from "./helpers";
+import { expectFilesInDist, expectToBeMyBoi } from "./helpers";
 import { bundlePath } from "./entities";
 
 declare global {
 	const xrange: typeof import("../../src");
 }
-
-beforeAll(build, 20000);
 
 it("should create all the necessary files", () => {
 	expectFilesInDist("xrange.bundle.js", [

--- a/test/build/commonjs.spec.ts
+++ b/test/build/commonjs.spec.ts
@@ -1,8 +1,6 @@
 import xrange from "../../dist";
 
-import { build, expectFilesInDist, expectToBeMyBoi } from "./helpers";
-
-beforeAll(build, 20000);
+import { expectFilesInDist, expectToBeMyBoi } from "./helpers";
 
 it("should create all the necessary files", () => {
 	expectFilesInDist("**/*.js", [

--- a/test/build/helpers.ts
+++ b/test/build/helpers.ts
@@ -1,15 +1,6 @@
 import { resolve, join } from "path";
-import { existsSync } from "fs";
-import { execSync } from "child_process";
 import { sync } from "glob";
-import { distPath, entryPath } from "./entities";
-
-export function build(done: jest.DoneCallback): void {
-	if (!existsSync(entryPath))
-		execSync("npm run build", { timeout: 20000, stdio: "ignore" });
-
-	done();
-}
+import { distPath } from "./entities";
 
 export function expectFilesInDist(glob: string, paths: string[]): void {
 	const actual = sync(join(distPath, glob)).map((path) => resolve(path));

--- a/test/build/typescript.spec.ts
+++ b/test/build/typescript.spec.ts
@@ -4,9 +4,7 @@ import type * as Predicate from "../../dist/typings/predicate";
 import type Memo from "../../dist/typings/memo";
 import type Prev from "../../dist/typings/prev";
 
-import { assert, t, build, expectFilesInDist } from "./helpers";
-
-beforeAll(build, 20000);
+import { assert, t, expectFilesInDist } from "./helpers";
 
 it("should create all the necessary files", () => {
 	expectFilesInDist("**/*.d.ts", [


### PR DESCRIPTION
This is cached, the dist/ should sometimes be rebuilt manually